### PR TITLE
(MODULES-4573) Sign-off edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 2. [Module Description - What the module does and why it is useful](#module-description)
 3. [Setup - The basics of getting started with docker_platform](#setup)
     * [Setup requirements](#setup-requirements)
-    * [Beginning with docker_platform](#beginning-with-docker-platform])
+    * [Beginning with docker_platform](#beginning-with-docker-platform)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 6. [Limitations - OS compatibility, etc.](#limitations)
@@ -20,17 +20,22 @@ The Puppet docker_platform module installs, configures, and manages the [Docker]
 
 ## Description
 
-This module lets you use Puppet to implement the Docker container system across a Puppet-managed infrastructure. It includes classes and defines to install the Docker daemon, manage images and containers across different nodesets, and run commands inside containers.
+This module lets you use Puppet to implement the Docker container system
+across a Puppet-managed infrastructure. It includes classes and defines to
+install the Docker daemon, manage images and containers across different
+nodesets, and run commands inside containers.
 
 ## Setup
 
 ### Setup requirements
 
-For Enterprise Linux 7 systems, a few issues might prevent Docker from starting properly. You can learn about these issues in the [Known Issues](#known-issues) section below.
+For Enterprise Linux 7 systems, a few issues might prevent Docker from
+starting properly. You can learn about these issues in the
+[Known Issues](#known-issues) section.
 
 ### Beginning with docker_platform
 
-To install Docker on a node, include the class `docker`.
+To install Docker on a node, include the `docker` class.
 
 ```puppet
 include 'docker'
@@ -38,14 +43,15 @@ include 'docker'
 
 This installs [Docker](https://github.com/docker/docker) from the [official
 repository](http://docs.docker.com/installation/) or alternatively from
-[EPEL on RedHat](http://docs.docker.io/en/latest/installation/rhel/)
+[EPEL on RedHat](https://docs.docker.com/engine/installation/linux/rhel/)
 based distributions.
 
 ## Usage
 
 ### Installing Docker
 
-You can install Docker with various parameters specified for the [`docker`](#docker) class:
+You can install Docker with various parameters specified for the
+[`docker`](#docker) class:
 
 ```puppet
 class {'docker':
@@ -57,12 +63,14 @@ class {'docker':
 }
 ```
 
-This example installs Docker version 0.5.5, binds the Docker daemon to a Unix socket and a tcp socket, provides the daemon with a dns server, and adds two users to the Docker group.
+This example installs Docker version 0.5.5, binds the Docker daemon to a Unix
+socket and a tcp socket, provides the daemon with a dns server, and adds two
+users to the Docker group.
 
-Docker recently [launched new official
+Docker [launched official
 repositories](http://blog.docker.com/2015/07/new-apt-and-yum-repos/#comment-247448)
-which are now the default for the module from version 5. If you want to
-stick with the old repositories you can do so with the following:
+that are the default for the module from version 5. If you want to
+stick with the old repositories, you can do so with the following:
 
 ```puppet
 class { 'docker':
@@ -74,9 +82,9 @@ class { 'docker':
 }
 ```
 
-The module also now uses the upstream repositories by default for RHEL
-based distros, including Fedora. If you want to stick with the distro
-packages you should use the following:
+The module also now uses the upstream repositories by default for RHEL-based
+distros, including Fedora. If you want to stick with the distro packages you
+should use the following:
 
 ```puppet
 class { 'docker':
@@ -93,7 +101,9 @@ To install a Docker image, use the define [`docker::image`](#dockerimage):
 docker::image { 'base': }
 ```
 
-This is equivalent to running `docker pull base`. This downloads a large binary, so on first run, it can take a while. For that reason, this define turns off the default five-minute timeout for exec.
+This is equivalent to running `docker pull base`. This downloads a large
+binary, so on first run, it can take a while. For that reason, this define
+turns off the default five-minute timeout for exec.
 
 ```puppet
 docker::image { 'ubuntu':
@@ -103,11 +113,14 @@ docker::image { 'ubuntu':
 }
 ```
 
-The above code adds an image from the listed Dockerfile. Alternatively, you can specify an image from a Docker directory, by using `docker_dir` parameter instead of `docker_file`.
+The above code adds an image from the listed Dockerfile. Alternatively, you
+can specify an image from a Docker directory, by using `docker_dir` parameter
+instead of `docker_file`.
 
 ### Containers
 
-Now that you have an image, you can run commands within a container managed by Docker:
+Now that you have an image, you can run commands within a container managed by
+Docker:
 
 ```puppet
 docker::run { 'helloworld':
@@ -116,15 +129,20 @@ docker::run { 'helloworld':
 }
 ```
 
-You can set ports, expose, env, dns, and volumes with either a single string or, as above, with an array of values.
+You can set ports, expose, env, dns, and volumes with either a single string
+or, as above, with an array of values.
 
 Specifying `pull_on_start` pulls the image before each time it is started.
 
-The `depends` option allows expressing containers that must be started before other containers start. This affects the generation of the init.d/systemd script.
+The `depends` option allows expressing containers that must be started before
+other containers start. This affects the generation of the init.d/systemd
+script.
 
-The service file created for systemd and upstart based systems enables automatic restarting of the service on failure by default.
+The service file created for systemd- and upstart-based systems enables
+automatic restarting of the service on failure by default.
 
-To use an image tag, append the tag name to the image name separated by a semicolon:
+To use an image tag, append the tag name to the image name separated by a
+semicolon:
 
 ```puppet
 docker::run { 'helloworld':
@@ -133,7 +151,8 @@ docker::run { 'helloworld':
 }
 ```
 
-If using Hiera, there's a `docker::run_instance` class you can configure, for example:
+If using Hiera, there's a `docker::run_instance` class you can configure,
+for example:
 
 ```puppet
 docker::run_instance::instance:
@@ -194,7 +213,7 @@ like so:
 
 ```puppet
 docker_compose { '/tmp/docker-compose.yml':
-  ensure  => present,
+  ensure => present,
 }
 ```
 
@@ -203,9 +222,9 @@ for example because the relevant Compose services aren't running.
 
 You can also pass addition options (for example to enable experimental
 features) as well as provide scaling rules. The following example
-requests 2 containers be running for example. Puppet will now run
-Compose if the number of containers for a given service don't match the
-provided scale values.
+requests two running containers. Puppet will now run Compose if the
+number of containers for a given service don't match the provided scale
+values.
 
 ```puppet
 docker_compose { '/tmp/docker-compose.yml':
@@ -213,15 +232,17 @@ docker_compose { '/tmp/docker-compose.yml':
   scale   => {
     'compose_test' => 2,
   },
-  options => '--x-networking'
+  options => '--x-networking',
 }
 ```
 
 ### Private registries
 
-By default images will be pushed and pulled from [The Docker Hub](https://hub.docker.com/).
-If you have your own private registry without authentication, you can fully qualify your image name.
-If your private registry requires authentication you may configure a registry using the following:
+By default images will be pushed and pulled from
+[Docker Hub](https://hub.docker.com/).
+If you have your own private registry without authentication, you can fully
+qualify your image name. If your private registry requires authentication,
+you can configure a registry using the following:
 
 ```puppet
 docker::registry { 'example.docker.io:5000':
@@ -231,7 +252,7 @@ docker::registry { 'example.docker.io:5000':
 }
 ```
 
-You can logout of a registry if it is no longer required.
+You can log out of a registry if it is no longer required:
 
 ```puppet
 docker::registry { 'example.docker.io:5000':
@@ -239,8 +260,7 @@ docker::registry { 'example.docker.io:5000':
 }
 ```
 
-If using Hiera, there's a `docker::registry_auth` class you can configure,
-for example:
+If using Hiera, you can configure the `docker::registry_auth` class:
 
 ```yaml
 docker::registry_auth::registries:
@@ -263,9 +283,11 @@ docker::exec { 'helloworld-uptime':
 }
 ```
 
-### Full Basic Example
+### Full basic example
 
-To install Docker, download a Ubuntu image, and run a Ubuntu-based container that does nothing except run the init process, you can use the following example manifest:
+To install Docker, download a Ubuntu image, and run a Ubuntu-based container
+that does nothing except run the init process, you can use the following
+example manifest:
 
 ```puppet
 class { 'docker':}
@@ -281,19 +303,23 @@ docker::run { 'test_1':
 }
 ```
 
-## Advanced Community Examples
+## Advanced community examples
 
-* [Launch vNext app in Docker using Puppet](https://github.com/garethr/puppet-docker-vnext-example)
+*   [Launch vNext app in Docker using Puppet](https://github.com/garethr/puppet-docker-vnext-example)
 
-This example contains a fairly simple example using Vagrant to launch a Linux virtual machine, then Puppet to install Docker, build an image and run a container. For added spice, the container runs a ASP.NET vNext application.
+    This example contains a fairly simple example using Vagrant to launch a
+    Linux virtual machine, then Puppet to install Docker, build an image, and
+    run a container. For added spice, the container runs a ASP.NET vNext
+    application.
 
-* [Multihost containers connected with Consul](https://github.com/garethr/puppet-docker-example)
+*   [Multihost containers connected with Consul](https://github.com/garethr/puppet-docker-example)
 
-Launch multiple containers and connect them together using Nginx, updated by Consul and Puppet.
+    Launch multiple containers and connect them together using Nginx,
+    updated by Consul and Puppet.
 
-* [Configure Docker Swarm using Puppet](https://github.com/garethr/puppet-docker-swarm-example)
+*   [Configure Docker Swarm using Puppet](https://github.com/garethr/puppet-docker-swarm-example)
 
-Build a cluster of hosts running Docker Swarm configured by Puppet.
+    Build a cluster of hosts running Docker Swarm configured by Puppet.
 
 ## Reference
 
@@ -304,19 +330,19 @@ is available as generated by Puppet Strings.
 If you would like a local copy of the module documentation simply install
 Puppet Strings as described in the [Strings
 documentation](https://github.com/puppetlabs/puppetlabs-strings) and
-then run the followin in the module directory.
+then run the following in the module directory.
 
 ```
 puppet strings
 ```
 
-This should create a directory called `doc` with all the HTML files in.
+This should create a directory called `doc` that contains all the HTML files.
 
 ## Limitations
 
 ### Support
 
-This module is currently supported on:
+This module is supported on:
 
 * RedHat Enterprise Linux 7.1 x86_64
 * CentOS 7.1 x86_64
@@ -324,28 +350,40 @@ This module is currently supported on:
 * Scientific Linux 7.1 x86_64
 * Ubuntu 14.04/16.04 x86_64
 
-### Known Issues
+### Known issues
 
-Depending on the initial state of your OS, you might run into issues which prevent Docker from starting properly:
+Depending on the initial state of your OS, you might run into issues that
+prevent Docker from starting properly:
 
 #### Enterprise Linux 7
 
-EL7 (RedHat/CentOS/Oracle/Scientific) requires at least version 1.02.93 of the device-mapper package to be installed for Docker's default configuration to work. That version is only available on EL7.1+.
+EL7 (RedHat/CentOS/Oracle/Scientific) requires at least version 1.02.93 of the
+device-mapper package to be installed for Docker's default configuration to
+work. That version is only available on EL7.1+.
 
 You can install this package via Puppet using the following manifest:
 
-~~~puppet
-package {'device-mapper':
+```puppet
+package { 'device-mapper':
   ensure => latest,
 }
-~~~
+```
 
-To ensure that device-mapper is installed before the `docker` class is executed, use the `before` or `require` [metaparameters](https://docs.puppetlabs.com/references/latest/metaparameter.html).
+To ensure that device-mapper is installed before the `docker` class is
+executed, use the `before` or `require`
+[metaparameters](https://docs.puppetlabs.com/references/latest/metaparameter.html).
 
 ## Development
-Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve. We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 
-For more information, see our [module contribution guide.](https://docs.puppetlabs.com/forge/contributing.html)
+Puppet Inc. modules on the Puppet Forge are open projects, and community
+contributions are essential for keeping them great. We can't access the huge
+number of platforms and myriad hardware, software, and deployment
+configurations that Puppet is intended to serve. We want to keep it as easy as
+possible to contribute changes so that our modules work in your environment.
+There are a few guidelines that we need contributors to follow so that we can
+have a chance of keeping on top of things.
+
+For more information, see our [module contribution guide.](https://docs.puppet.com/forge/contributing.html)
 
 To see who's already involved, see the [list of contributors.](https://github.com/puppetlabs/puppetlabs-docker_platform/graphs/contributors)
 


### PR DESCRIPTION
- Updates some links to Docker docs.
- Fixes a broken ToC link.
- Fixes a typo.
- Updates some formatting and text to match Puppet style.
- Fixes Puppet branding.
- Consistently breaks lines.

Needs feedback or additional changes:

- Should we specify that this installs Docker CE?
- http://docs.docker.io/en/latest/installation/rhel/ no longer exists and does not redirect. Replaced a link on L41 to that with https://docs.docker.com/engine/installation/linux/rhel/, which notes that Docker CE is not supported on RHEL.
- On L70, the old repo example points to a script at https://get.docker.com/ubuntu, which is deprecated, does nothing but echo a deprecation notice that refers users to a script at https://get.docker.com/, and exits with error code 1.